### PR TITLE
Add resistance system with adjustable cap

### DIFF
--- a/Assets/Scripts/RPG_Basic_Stats.cs
+++ b/Assets/Scripts/RPG_Basic_Stats.cs
@@ -11,6 +11,7 @@ public class RPG_Basic_Stats
     public int armour;
     public int evasion;
     public RPG_EnergyShieldStats energyShield = new RPG_EnergyShieldStats();
+    public RPG_ResistanceStats resistances = new RPG_ResistanceStats();
 
     public static RPG_Basic_Stats operator +(RPG_Basic_Stats a, RPG_Basic_Stats b)
     {
@@ -33,6 +34,7 @@ public class RPG_Basic_Stats
         result.energyShield.regeneration = a.energyShield.regeneration + b.energyShield.regeneration;
         result.energyShield.rechargeRate = a.energyShield.rechargeRate + b.energyShield.rechargeRate;
         result.energyShield.rechargeDelay = Mathf.Max(a.energyShield.rechargeDelay, b.energyShield.rechargeDelay);
+        result.resistances = a.resistances + b.resistances;
         return result;
     }
 
@@ -40,6 +42,6 @@ public class RPG_Basic_Stats
     {
         return $"STR:{strength} DEX:{dexterity} INT:{intelligence} " +
                $"{life} {mana} Armour:{armour} " +
-               $"Evasion:{evasion} {energyShield}";
+               $"Evasion:{evasion} {energyShield} {resistances}";
     }
 }

--- a/Assets/Scripts/RPG_ResistanceStats.cs
+++ b/Assets/Scripts/RPG_ResistanceStats.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[System.Serializable]
+public class RPG_ResistanceStats
+{
+    [Tooltip("Elemental fire resistance in percentage")] public float fire;
+    [Tooltip("Elemental cold resistance in percentage")] public float cold;
+    [Tooltip("Elemental lightning resistance in percentage")] public float lightning;
+    [Tooltip("Chaos resistance in percentage")] public float chaos;
+    [Tooltip("Additional maximum resistance above the default cap")] public float maxResistanceBonus;
+
+    public float MaxResistance => 75f + maxResistanceBonus;
+
+    public float GetResistance(RPG_DamageTypes type, bool ignoreCap = false)
+    {
+        float value = 0f;
+        switch (type)
+        {
+            case RPG_DamageTypes.Fire: value = fire; break;
+            case RPG_DamageTypes.Cold: value = cold; break;
+            case RPG_DamageTypes.Lightning: value = lightning; break;
+            case RPG_DamageTypes.Chaos: value = chaos; break;
+            case RPG_DamageTypes.Physical: value = 0f; break;
+        }
+        return ignoreCap ? value : Mathf.Min(value, MaxResistance);
+    }
+
+    public float DamageAfterResistance(RPG_DamageTypes type, float damage, bool ignoreCap = false)
+    {
+        float res = GetResistance(type, ignoreCap);
+        return damage * (1f - res / 100f);
+    }
+
+    public static RPG_ResistanceStats operator +(RPG_ResistanceStats a, RPG_ResistanceStats b)
+    {
+        var result = new RPG_ResistanceStats();
+        result.fire = a.fire + b.fire;
+        result.cold = a.cold + b.cold;
+        result.lightning = a.lightning + b.lightning;
+        result.chaos = a.chaos + b.chaos;
+        result.maxResistanceBonus = a.maxResistanceBonus + b.maxResistanceBonus;
+        return result;
+    }
+
+    public override string ToString()
+    {
+        return $"FireRes:{fire}% ColdRes:{cold}% LightningRes:{lightning}% ChaosRes:{chaos}% MaxRes:{MaxResistance}%";
+    }
+}

--- a/Assets/Scripts/RPG_ResistanceStats.cs.meta
+++ b/Assets/Scripts/RPG_ResistanceStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9827a3be-4588-4ba2-8d02-fa2ef7ffead3


### PR DESCRIPTION
## Summary
- implement `RPG_ResistanceStats` to hold elemental and chaos resistances
- allow increasing maximum resistance above the default 75% cap
- combine resistance stats in `RPG_Basic_Stats`

## Testing
- `true`